### PR TITLE
Allow to create a readonly table (without selection checkbox)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/react-formiga-table",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-formiga-table",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "react": "^16.8.0 || 17.x",
         "react-dom": "^16.8.0 || 17.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-formiga-table",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "scripts": {
     "build": "tsc && vite build",
     "prepublishOnly": "npm run build",

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -21,6 +21,7 @@ export const Table = (props: TableProps) => {
     sorter,
     expandableOpts,
     onCellRender,
+    readonly
   } = props;
 
   if (loading) {
@@ -86,6 +87,7 @@ export const Table = (props: TableProps) => {
               handleColumnClick={handleColumnClick}
               getColumnSorter={getColumnSorter}
               sortEnabled={expandableOpts === undefined}
+              readonly={readonly}
             />
           </tr>
         </thead>
@@ -106,6 +108,7 @@ export const Table = (props: TableProps) => {
             getChildsForParent={getChildsForParent}
             getLevelForKey={getLevelForKey}
             onCellRender={onCellRender}
+            readonly={readonly}
           />
         </tbody>
       </table>

--- a/src/components/Headers.tsx
+++ b/src/components/Headers.tsx
@@ -10,6 +10,7 @@ export const Headers = ({
   handleColumnClick,
   getColumnSorter,
   sortEnabled,
+  readonly,
 }: {
   onRowSelectionChange?: (selectedRowItems: any[]) => void;
   allRowsAreSelected: boolean;
@@ -19,10 +20,11 @@ export const Headers = ({
   handleColumnClick: (columnId: string) => void;
   getColumnSorter: (columnId: string) => Sorter | undefined;
   sortEnabled: boolean;
+  readonly?: boolean;
 }) => {
   return (
     <>
-      {onRowSelectionChange && (
+      {onRowSelectionChange && !readonly && (
         <th
           style={{
             width: 10,

--- a/src/components/Rows.tsx
+++ b/src/components/Rows.tsx
@@ -25,6 +25,7 @@ export const Rows = ({
   getChildsForParent,
   getLevelForKey,
   onCellRender,
+  readonly,
 }: {
   onRowSelectionChange?: (selectedRowItems: any[]) => void;
   dataSource: any[];
@@ -41,6 +42,7 @@ export const Rows = ({
   getChildsForParent: (key: number) => any[] | undefined;
   getLevelForKey: (key: number) => number;
   onCellRender?: (opts: OnCellRenderOpts) => React.ReactNode;
+  readonly?: boolean;
 }) => {
   return (
     <>
@@ -63,6 +65,7 @@ export const Rows = ({
             getColumnSorter,
             keyIsOpened,
             getChildsForParent,
+            readonly,
           });
         })}
     </>
@@ -85,6 +88,7 @@ function getRowComponent({
   onRowStyle,
   level = 0,
   onCellRender,
+  readonly,
 }: {
   row: any;
   columns: TableColumn[];
@@ -101,6 +105,7 @@ function getRowComponent({
   onRowStyle: (item: any) => any;
   level?: number;
   onCellRender?: (opts: OnCellRenderOpts) => React.ReactNode;
+  readonly?: boolean;
 }): React.ReactNode {
   const style = onRowStyle(row);
   const rowIsSelected = isRowSelected(row);
@@ -112,7 +117,7 @@ function getRowComponent({
         onRowDoubleClick?.(row);
       }}
     >
-      {onRowSelectionChange && (
+      {onRowSelectionChange && !readonly && (
         <td
           key={`react_formiga_table_selection-${row.id}`}
           style={{
@@ -129,21 +134,14 @@ function getRowComponent({
               alignItems: "center",
             }}
           >
-            {rowIsSelected ? (
-              <Checkbox
-                value={true}
-                onChange={() => {
-                  toggleRowSelected(row);
-                }}
-              />
-            ) : (
-              <Checkbox
-                value={false}
-                onChange={() => {
-                  toggleRowSelected(row);
-                }}
-              />
-            )}
+            {!readonly &&
+          <Checkbox
+            value={rowIsSelected}
+            onChange={() => {
+              toggleRowSelected(row);
+            }}
+          />
+            }
           </div>
         </td>
       )}

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -119,6 +119,111 @@ export const Primary: ComponentStoryObj<typeof Table> = {
   },
 };
 
+
+export const Readonly: ComponentStoryObj<typeof Table> = {
+  args: {
+    loading: false,
+    loadingComponent: <Spin />,
+    height: 300,
+    onRowSelectionChange: (selectedRows: any) => {
+      console.log("selectedRows: " + JSON.stringify(selectedRows));
+    },
+    onRowStyle: () => undefined,
+    onRowDoubleClick: (record: any) => {
+      alert("double clicked record" + JSON.stringify(record));
+    },
+    sorter: { id: "name", desc: true },
+    readonly: true,
+    onChangeSort: (sorter: Sorter | undefined) => {
+      console.log("onChangeSort: ", sorter);
+    },
+    columns: [
+      {
+        title: "Name",
+        key: "name",
+      },
+      {
+        title: "Surnames",
+        key: "surnames",
+      },
+      {
+        title: "Address",
+        key: "address",
+      },
+      {
+        title: "Address 2",
+        key: "address2",
+      },
+      {
+        title: "Address 3",
+        key: "address3",
+      },
+      {
+        title: "Address",
+        key: "address",
+      },
+      {
+        title: "Address 2",
+        key: "address2",
+      },
+      {
+        title: "Address 3",
+        key: "address3",
+      },
+      {
+        title: "Address",
+        key: "address",
+      },
+      {
+        title: "Address 2",
+        key: "address2",
+      },
+      {
+        title: "Address 3",
+        key: "address3",
+      },
+      {
+        title: "Image",
+        key: "image",
+        render: (item: any) => {
+          return <img src={item} />;
+        },
+      },
+      {
+        title: "Object",
+        key: "object",
+        render: (item: any) => {
+          return <pre>{JSON.stringify(item, null, 2)}</pre>;
+        },
+      },
+    ],
+    dataSource: [
+      {
+        id: 0,
+        name: "A. John",
+        surnames: "Doe",
+        image:
+          "https://pickaface.net/gallery/avatar/unr_sample_161118_2054_ynlrg.png",
+        object: {
+          model: "test",
+          value: "Test value",
+        },
+      },
+      {
+        id: 1,
+        name: "B. Jane",
+        surnames: "Doe",
+        image:
+          "https://pickaface.net/gallery/avatar/unr_sample_170130_2257_9qgawp.png",
+        object: {
+          model: "test",
+          value: "Test value",
+        },
+      },
+    ],
+  },
+};
+
 const otherChilds = [
   { id: 2, name: "R. Kate", surnames: "Hellington", child_id: [4, 5] },
   { id: 4, name: "Four Bob", surnames: "Asdt" },

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -42,4 +42,5 @@ export type TableProps = {
   loadingComponent: any;
   height?: number;
   onCellRender?: (opts: OnCellRenderOpts) => React.ReactNode;
+  readonly?: boolean;
 };


### PR DESCRIPTION
- Add a new prop `readonly` to hide the checkbox to select rows.
- This change should be compatible backwards
