### PR TITLE
Allow Row Status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/react-formiga-table",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-formiga-table",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "react": "^16.8.0 || 17.x",
         "react-dom": "^16.8.0 || 17.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-formiga-table",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "scripts": {
     "build": "tsc && vite build",
     "prepublishOnly": "npm run build",

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -16,6 +16,7 @@ export const Table = (props: TableProps) => {
     columns,
     onRowDoubleClick,
     onRowStyle,
+    onRowStatus,
     onRowSelectionChange,
     onChangeSort,
     sorter,
@@ -88,6 +89,7 @@ export const Table = (props: TableProps) => {
               getColumnSorter={getColumnSorter}
               sortEnabled={expandableOpts === undefined}
               readonly={readonly}
+              status={!!onRowStatus}
             />
           </tr>
         </thead>
@@ -99,6 +101,7 @@ export const Table = (props: TableProps) => {
             getColumnSorter={getColumnSorter}
             onRowDoubleClick={onRowDoubleClick}
             onRowStyle={onRowStyle}
+            onRowStatus={onRowStatus}
             isRowSelected={isRowSelected}
             toggleRowSelected={toggleRowSelected}
             expandableOpts={expandableOpts}

--- a/src/components/Headers.tsx
+++ b/src/components/Headers.tsx
@@ -11,6 +11,7 @@ export const Headers = ({
   getColumnSorter,
   sortEnabled,
   readonly,
+  status = false,
 }: {
   onRowSelectionChange?: (selectedRowItems: any[]) => void;
   allRowsAreSelected: boolean;
@@ -21,6 +22,7 @@ export const Headers = ({
   getColumnSorter: (columnId: string) => Sorter | undefined;
   sortEnabled: boolean;
   readonly?: boolean;
+  status?: boolean;
 }) => {
   return (
     <>
@@ -56,6 +58,10 @@ export const Headers = ({
           </div>
         </th>
       )}
+      {status &&
+        <th key="th-status">
+        </th>
+      }
       {columns.map((column: any) => (
         <th
           key={column.key}

--- a/src/components/Rows.tsx
+++ b/src/components/Rows.tsx
@@ -15,6 +15,7 @@ export const Rows = ({
   columns,
   getColumnSorter,
   onRowStyle,
+  onRowStatus,
   onRowDoubleClick,
   isRowSelected,
   toggleRowSelected,
@@ -32,6 +33,7 @@ export const Rows = ({
   columns: TableColumn[];
   getColumnSorter: (columnId: string) => Sorter | undefined;
   onRowStyle: (item: any) => any;
+  onRowStatus?: (item: any) => any;
   onRowDoubleClick?: (item: any) => void;
   isRowSelected: (row: any) => boolean;
   toggleRowSelected: (row: any) => void;
@@ -55,6 +57,7 @@ export const Rows = ({
             row,
             columns,
             onRowStyle,
+            onRowStatus,
             onRowDoubleClick,
             onRowSelectionChange,
             isRowSelected,
@@ -86,6 +89,7 @@ function getRowComponent({
   keyIsOpened,
   getChildsForParent,
   onRowStyle,
+  onRowStatus,
   level = 0,
   onCellRender,
   readonly,
@@ -103,6 +107,7 @@ function getRowComponent({
   keyIsOpened: (key: number) => boolean;
   getChildsForParent: (key: number) => any[] | undefined;
   onRowStyle: (item: any) => any;
+  onRowStatus?: (item: any) => any;
   level?: number;
   onCellRender?: (opts: OnCellRenderOpts) => React.ReactNode;
   readonly?: boolean;
@@ -145,6 +150,22 @@ function getRowComponent({
           </div>
         </td>
       )}
+      {onRowStatus &&
+        <>
+        <Cell
+          row={row}
+          key={`status-${row.id}`}
+          getColumnSorter={() => undefined}
+          column="row-status"
+          columnIdx={-1}
+          onCellRender={() => onRowStatus(row)}
+          expandableOpts={expandableOpts}
+          getExpandableStatusForRow={getExpandableStatusForRow}
+          onExpandableIconClicked={onExpandableIconClicked}
+          level={level}
+        />
+        </>
+      }
       {columns.map((column: any, columnIdx: number) => {
         return (
           <Cell

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -223,6 +223,138 @@ export const Readonly: ComponentStoryObj<typeof Table> = {
   },
 };
 
+
+const BadgeStatus = (props: any) => {
+  console.log(props);
+  return (
+    <span style={{
+      backgroundColor: props.color,
+      borderRadius: '50%',
+      width: '6px',
+      height: '6px',
+      lineHeight: '22px',
+      fontSize: '14px',
+      boxSizing: 'border-box',
+      display: 'inline-block',
+    }}></span>
+  )
+}
+
+
+function getStatusForItem(item: any): any {
+  if (item.id === 1) {
+    return <BadgeStatus color="#52c41a" />
+  } else if (item.id === 0) {
+    return <BadgeStatus color="#faad14" />
+  }
+}
+
+
+export const Status: ComponentStoryObj<typeof Table> = {
+  args: {
+    loading: false,
+    loadingComponent: <Spin />,
+    height: 300,
+    onRowSelectionChange: (selectedRows: any) => {
+      console.log("selectedRows: " + JSON.stringify(selectedRows));
+    },
+    onRowStyle: () => undefined,
+    onRowStatus: getStatusForItem,
+    onRowDoubleClick: (record: any) => {
+      alert("double clicked record" + JSON.stringify(record));
+    },
+    sorter: { id: "name", desc: true },
+    readonly: true,
+    onChangeSort: (sorter: Sorter | undefined) => {
+      console.log("onChangeSort: ", sorter);
+    },
+    columns: [
+      {
+        title: "Name",
+        key: "name",
+      },
+      {
+        title: "Surnames",
+        key: "surnames",
+      },
+      {
+        title: "Address",
+        key: "address",
+      },
+      {
+        title: "Address 2",
+        key: "address2",
+      },
+      {
+        title: "Address 3",
+        key: "address3",
+      },
+      {
+        title: "Address",
+        key: "address",
+      },
+      {
+        title: "Address 2",
+        key: "address2",
+      },
+      {
+        title: "Address 3",
+        key: "address3",
+      },
+      {
+        title: "Address",
+        key: "address",
+      },
+      {
+        title: "Address 2",
+        key: "address2",
+      },
+      {
+        title: "Address 3",
+        key: "address3",
+      },
+      {
+        title: "Image",
+        key: "image",
+        render: (item: any) => {
+          return <img src={item} />;
+        },
+      },
+      {
+        title: "Object",
+        key: "object",
+        render: (item: any) => {
+          return <pre>{JSON.stringify(item, null, 2)}</pre>;
+        },
+      },
+    ],
+    dataSource: [
+      {
+        id: 0,
+        name: "A. John",
+        surnames: "Doe",
+        image:
+          "https://pickaface.net/gallery/avatar/unr_sample_161118_2054_ynlrg.png",
+        object: {
+          model: "test",
+          value: "Test value",
+        },
+      },
+      {
+        id: 1,
+        name: "B. Jane",
+        surnames: "Doe",
+        image:
+          "https://pickaface.net/gallery/avatar/unr_sample_170130_2257_9qgawp.png",
+        object: {
+          model: "test",
+          value: "Test value",
+        },
+      },
+    ],
+  },
+};
+
 const otherChilds = [
   { id: 2, name: "R. Kate", surnames: "Hellington", child_id: [4, 5] },
   { id: 4, name: "Four Bob", surnames: "Asdt" },

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -32,6 +32,7 @@ export type TableProps = {
   dataSource: any[];
   columns: TableColumn[];
   onRowStyle: (item: any) => any;
+  onRowStatus?: (item: any) => any;
   onRowDoubleClick?: (item: any) => void;
   onRowSelectionChange?: (selectedRowItems: any[]) => void;
   sortEnabled?: boolean;


### PR DESCRIPTION
Allow to define a new callback `onRowStatus` which receives the row and should return a component to display.


![image](https://github.com/gisce/react-formiga-table/assets/294235/597f9c72-60d1-4792-ab53-a9b5553ba749)
