### PR TITLE
update gisce/commitlint-rules to v1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@commitlint/cli": "^18.4.3",
-        "@gisce/commitlint-rules": "1.0.5",
+        "@gisce/commitlint-rules": "1.0.6",
         "@semantic-release/exec": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/npm": "10.0.4",
@@ -3132,9 +3132,9 @@
       "dev": true
     },
     "node_modules/@gisce/commitlint-rules": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@gisce/commitlint-rules/-/commitlint-rules-1.0.5.tgz",
-      "integrity": "sha512-L3czIEMS8gYbGpJEg3xHpby6QPWuhRGFJ4NsPuRLA9uFfDTTVOq19Y2jrnt0UNg6zOJKwRVSdkX5Aio8gTP1dg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@gisce/commitlint-rules/-/commitlint-rules-1.0.6.tgz",
+      "integrity": "sha512-DbpBbKv7EBZ0LQuCUT+3R93Uu4GKsDi4ck1qkMLBogXOt/cjLUQGWHKpA7DZcNLy3RZKKJpf9DBHiPeCjFtq8g==",
       "dev": true,
       "dependencies": {
         "@commitlint/config-conventional": "^18.4.3"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
-    "@gisce/commitlint-rules": "1.0.5",
+    "@gisce/commitlint-rules": "1.0.6",
     "@semantic-release/exec": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/npm": "10.0.4",


### PR DESCRIPTION
This PR updates [gisce/commitlint-rules](https://github.com/gisce/commitlint-rules) to [v1.0.6](https://github.com/gisce/commitlint-rules/releases/tag/v1.0.6).