### PR TITLE
fix: reset pinned columns in paginated table

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -376,6 +376,7 @@ const PaginatedTableComp = forwardRef<PaginatedTableRef, PaginatedTableProps>(
           headerName: column.title,
           sort: initialSort?.sort,
           sortIndex: initialSort?.sortIndex,
+          pinned: false,
           cellRenderer: column.render
             ? (cell: any) => column.render(cell.value, cell.data)
             : undefined,


### PR DESCRIPTION
https://github.com/gisce/webclient/issues/1968