### PR TITLE
fix: remove hardcoded minWidth from InfiniteTable and PaginatedTable …

### DIFF
--- a/src/components/InfiniteTable/InfiniteTable.tsx
+++ b/src/components/InfiniteTable/InfiniteTable.tsx
@@ -258,7 +258,6 @@ const InfiniteTableComp = forwardRef<InfiniteTableRef, InfiniteTableProps>(
         return {
           field: column.key,
           sortable: column.isSortable,
-          minWidth: 100,
           headerName: column.title,
           sort: initialSort?.sort,
           sortIndex: initialSort?.sortIndex,

--- a/src/components/InfiniteTable/useColumnState.ts
+++ b/src/components/InfiniteTable/useColumnState.ts
@@ -10,6 +10,7 @@ import { useDeepCompareCallback } from "use-deep-compare";
 import { dequal } from "dequal";
 
 const DEBOUNCE_DELAY = 50;
+const INITIAL_MIN_COLUMN_WIDTH = 100;
 const INITIAL_MAX_COLUMN_WIDTH = 400;
 
 export const useColumnState = ({
@@ -74,15 +75,19 @@ export const useColumnState = ({
       const allColumns = gridRef?.current?.api.getAllGridColumns();
       if (!allColumns) return;
 
-      // Cap column widths to INITIAL_MAX_COLUMN_WIDTH
-      if (type === "paginated") {
-        const state = gridRef?.current?.api.getColumnState()!;
-        const cappedState = state.map((col: any) => ({
-          ...col,
-          width: Math.min(col.width || 0, INITIAL_MAX_COLUMN_WIDTH),
-        }));
-        gridRef?.current?.api.applyColumnState({ state: cappedState });
-      }
+      // Cap column widths based on table type
+      const state = gridRef?.current?.api.getColumnState()!;
+      const cappedState = state.map((col: any) => ({
+        ...col,
+        width:
+          type === "paginated"
+            ? Math.min(
+                Math.max(col.width || 0, INITIAL_MIN_COLUMN_WIDTH),
+                INITIAL_MAX_COLUMN_WIDTH,
+              )
+            : Math.max(col.width || 0, INITIAL_MIN_COLUMN_WIDTH),
+      }));
+      gridRef?.current?.api.applyColumnState({ state: cappedState });
 
       // Calculate remaining blank space after capping
       const blankSpace = remainingBlankSpace(allColumns);

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -45,7 +45,6 @@ const DEFAULT_COL_DEF: ColDef = {
   sortable: false,
   comparator: () => 0,
   resizable: true,
-  minWidth: 100, // Minimum column width to ensure readability
   valueFormatter: () => {
     // To skip warnings, return an empty string, we'll handle ourself the value in the cellRenderer
     return "";


### PR DESCRIPTION
…and use it only at startup

https://github.com/gisce/webclient/issues/1986
- Removed minWidth property from column definitions in InfiniteTable and PaginatedTable components.
- Introduced INITIAL_MIN_COLUMN_WIDTH constant in useColumnState for better management of minimum column width based on table type.