### PR TITLE
fix: cap initial width too for columns in infinite trees

### DIFF
--- a/src/components/InfiniteTable/useColumnState.ts
+++ b/src/components/InfiniteTable/useColumnState.ts
@@ -79,13 +79,10 @@ export const useColumnState = ({
       const state = gridRef?.current?.api.getColumnState()!;
       const cappedState = state.map((col: any) => ({
         ...col,
-        width:
-          type === "paginated"
-            ? Math.min(
-                Math.max(col.width || 0, INITIAL_MIN_COLUMN_WIDTH),
-                INITIAL_MAX_COLUMN_WIDTH,
-              )
-            : Math.max(col.width || 0, INITIAL_MIN_COLUMN_WIDTH),
+        width: Math.min(
+          Math.max(col.width || 0, INITIAL_MIN_COLUMN_WIDTH),
+          INITIAL_MAX_COLUMN_WIDTH,
+        ),
       }));
       gridRef?.current?.api.applyColumnState({ state: cappedState });
 


### PR DESCRIPTION
https://github.com/gisce/webclient/issues/2021